### PR TITLE
통신없이 챌린지 시작하기 후 화면 구성

### DIFF
--- a/lib/data/dtos/challenge/challenge_response.dart
+++ b/lib/data/dtos/challenge/challenge_response.dart
@@ -92,6 +92,7 @@ class ChallengeDetailDTO {
   String subTitle; // 부 제목
   int walking; // 걸어야할 걸음수
   String content; // 챌린지 내용
+  int coin;
   bool? state;
   String backgroundImg;
 
@@ -102,6 +103,7 @@ class ChallengeDetailDTO {
       required this.walking,
       required this.content,
       this.state,
+      required this.coin,
       required this.backgroundImg});
 
   factory ChallengeDetailDTO.fromJson(Map<String, dynamic> json) {
@@ -111,9 +113,36 @@ class ChallengeDetailDTO {
       subTitle: json["subTitle"],
       walking: json["walking"],
       content: json["content"],
+      coin: json["coin"],
       state: json["state"] ?? null,
       backgroundImg: json["backgroundImg"],
     );
   }
 // 챌린지 내용
+}
+
+class ChallengeStartDTO {
+  final int userId;
+  final int challengeId;
+  final DateTime openingTime;
+  final DateTime closingTime;
+  final bool? status;
+
+  ChallengeStartDTO(
+      {required this.userId,
+      required this.challengeId,
+      required this.openingTime,
+      required this.closingTime,
+      this.status});
+
+  factory ChallengeStartDTO.fromJson(Map<String, dynamic> json) {
+    return ChallengeStartDTO(
+      userId: json["userId"],
+      challengeId: json["challengeId"],
+      openingTime: DateTime.parse(json["openingTime"]),
+      closingTime: DateTime.parse(json["closingTime"]),
+      status: json["status"],
+    );
+  }
+//
 }

--- a/lib/ui/main/challenge/pages/ongoing_challenge_detail_page.dart
+++ b/lib/ui/main/challenge/pages/ongoing_challenge_detail_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:project_app/_core/constants/constants.dart';
 import 'package:project_app/data/dtos/challenge/challenge_response.dart';
+
 import '../widgets/ongoing_challenge_img.dart';
 import '../widgets/ongoing_challenge_percent.dart';
 import '../widgets/ongoing_challenge_progress_bar.dart';
@@ -17,8 +18,7 @@ class OngoingChallengeDetailPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-
-    int? currentSteps = challenge!.totalWalking; // 테스트용 값
+    int? currentSteps = challenge!.totalWalking;
     int? totalSteps = challenge!.walking;
     double progress = _calculateProgress(currentSteps!, totalSteps!) * 100;
 
@@ -34,10 +34,15 @@ class OngoingChallengeDetailPage extends StatelessWidget {
             children: [
               OngoingChallengeImg(progress: progress / 100),
               const SizedBox(height: 20),
-              Text("${challenge?.challengeName}", style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: kAccentColor2)),
+              Text("${challenge?.challengeName}",
+                  style: TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                      color: kAccentColor2)),
               SizedBox(height: 10),
               Text("${challenge?.subtitle ?? 'No subtitle provided'}",
-                  style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600)),
+                  style: const TextStyle(
+                      fontSize: 12, fontWeight: FontWeight.w600)),
               const SizedBox(height: 20),
               OngoingChallengeProgressBar(progress: progress),
               const SizedBox(height: 20),

--- a/lib/ui/main/challenge/viewmodel/challenge_view_model.dart
+++ b/lib/ui/main/challenge/viewmodel/challenge_view_model.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:project_app/data/dtos/challenge/challenge_response.dart';
 import 'package:project_app/data/dtos/response_dto.dart';
 import 'package:project_app/data/repository/challenge_respository.dart';
-import 'package:project_app/data/store/session_store.dart';
 import 'package:project_app/main.dart';
 
 class ChallengeListModel {
@@ -21,10 +20,22 @@ class ChallengeListViewModel extends StateNotifier<ChallengeListModel?> {
 
   ChallengeListViewModel(super._state, this.ref);
 
+  Future<void> startChallenge(AttendChallenge attendChallenge) async {
+    ChallengeListModel prevModel = state!;
+    List<ChallengeListDTO> upcomingChallenge =
+        prevModel.upcomingChallengeDTOList!;
+
+    upcomingChallenge
+        .removeWhere((challenge) => challenge.id == attendChallenge.id);
+
+    ChallengeListModel newModel = ChallengeListModel(
+        attendChallenge, upcomingChallenge, prevModel.pastChallengesDTOList);
+
+    state = newModel;
+  }
+
   Future<void> notifyInit() async {
-    SessionStore sessionStore = ref.read(sessionProvider);
-    ResponseDTO responseDTO =
-        await ChallengeRepository().getChallengeList();
+    ResponseDTO responseDTO = await ChallengeRepository().getChallengeList();
 
     ChallengeResponseDTO challengeResponseDTO =
         ChallengeResponseDTO.fromJson(responseDTO.body);


### PR DESCRIPTION
## 구현
- 진행중인 챌린지 없던 사람이 챌린지 참가시 통신없이 챌린지 리스트 화면 전환

## 추후 변경 필요
- ongoingChallenge 상세보기의 현재 걸음수 만보기랑 연동 필요