### PR TITLE
설문 완료 후 페이지 통신없이 갱신

### DIFF
--- a/lib/ui/main/my/viewmodel/survey_page_viewmodel.dart
+++ b/lib/ui/main/my/viewmodel/survey_page_viewmodel.dart
@@ -18,6 +18,17 @@ class SurveyListViewModel extends StateNotifier<SurveyListModel?> {
 
   SurveyListViewModel(super._state, this.ref);
 
+  void surveyResultUpdate(int surveyId) {
+    List<SurveyResponseDTO> newJoinableSurveyList = state!.joinableSurveyList!
+      ..removeWhere((element) => element.id == surveyId);
+    List<SurveyResponseDTO> newUnjoinableSurveyList = state!
+        .unjoinableSurveyList!
+      ..add(state!.joinableSurveyList!
+          .firstWhere((element) => element.id == surveyId));
+
+    state = SurveyListModel(newJoinableSurveyList, newUnjoinableSurveyList);
+  }
+
   Future<void> notifyInit() async {
     ResponseDTO responseDTO = await SurveyRepository().fetchSurvey();
     if (responseDTO.status == 200) {


### PR DESCRIPTION
## 구현
- 설문 결과 insert 후 설문 페이지 통신없이 참여챌린지 -> 지난챌린지로 이동